### PR TITLE
Changing the default method in the fastq2fasta.py file

### DIFF
--- a/bioconvert/fastq2fasta.py
+++ b/bioconvert/fastq2fasta.py
@@ -40,7 +40,8 @@ class FASTQ2FASTA(ConvBase):
     # though. Make sure that the default handles also the compresssion
     # input_ext = extensions.extensions.fastq
     # output_ext =  extensions.fasta
-    _default_method = "readfq"
+    #_default_method = "readfq"
+    _default_method = "python_internal"
 
     def __init__(self, infile, outfile):
         """


### PR DESCRIPTION
Changed the default method to the 'python _internal' method, the fastest method globally in the **fastq2fasta.py** file