### PR TITLE
updated version that was fixed to 1.0.0

### DIFF
--- a/bioconvert/__init__.py
+++ b/bioconvert/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.0"
+__version__ = "1.1.1"
 import pkg_resources
 
 try:


### PR DESCRIPTION
when using `bioconvert --version` is shows 1.0.0 when installed version is 1.1.1
inconsistency is due to `setup.py` using a version but command line interface is showing a different version